### PR TITLE
add Trezor (FIDO/FIDO2 token) to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 ## Hardware
  - [Conor Patrick: U2F Zero](https://github.com/conorpp/u2f-zero) - U2F Zero is an open source U2F token for 2 factor authentication.
  - [SoloKeys](https://github.com/solokeys) - Solo is an open source FIDO2 security key, and you can get one at solokeys.com.
+ - [Trezor](https://github.com/trezor/trezor-core/tree/master/src/apps/webauthn) - Trezor is an open source hardware wallet with FIDO/U2F and FIDO2/WebAuthn functionality. You can get one at https://shop.trezor.io/
 
 # Resources
 ## Tutorials


### PR DESCRIPTION
This adds Trezor (U2F/WebAuthn token) to the README