### PR TITLE
Update WebAuthn4J status

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
  - [Adam Powers: FIDO2 lib](https://github.com/apowers313/fido2-lib)
  - [Anders Åberg: .NET library for FIDO2](https://github.com/abergs/fido2-net-lib) - A working implementation library + demo for fido2 and WebAuthn using .NET. `FIDO COMPLIANT`
  - [Nov Matake: Ruby WebAuthn Lib](https://github.com/nov/web_authn) - W3C Web Authentication API (a.k.a. WebAuthN / FIDO 2.0) RP library in Ruby
- - [Yoshikazu Nojima: WebAuthn4J](https://github.com/webauthn4j/webauthn4j) - A portable Java library for WebAuthn server side verification
+ - [WebAuthn4J Project: WebAuthn4J](https://github.com/webauthn4j/webauthn4j) - A portable Java library for WebAuthn server side verification `FIDO COMPLIANT`
  - [Yubico: python-fido2](https://github.com/Yubico/python-fido2) - FIDO2 Client and Server lib
  - [cedarcode: WebAuthn Ruby](https://github.com/cedarcode/webauthn-ruby) - Ruby implementation of a WebAuthn Relying Party
  - [Tangui: Wax](https://github.com/tanguilp/wax) - Elixir implementation of WebAuthn


### PR DESCRIPTION
Could you mark WebAuthn4J as `FIDO COMPLIANT`?
It passed FIDO Conformance Tools v0.10.192 on Feb. 4th 2019.
![image](https://user-images.githubusercontent.com/2139672/57387324-141cce80-71f1-11e9-9d4b-38e3be43e7b2.png)

(With latest v1.1.1, it faces attestation certificate problem reported on https://github.com/fido-alliance/conformance-tools-issues/issues/461. I'll try again when it is resolved. )