### PR TITLE
add soft-webauthn

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@
  - [Yubico: libfido2](https://github.com/Yubico/libfido2) - C client library and command-line tools to communicate with a FIDO device over USB, and to verify attestation and assertion signatures.
  - [Lyo Kato: iOS Webauthn Kit](https://github.com/lyokato/WebAuthnKit) - This library provides you a way to handle W3C Web Authentication API (a.k.a. WebAuthN / FIDO 2.0) easily.
  - [Damian Czaja: android-webauthn-token](https://github.com/Trojan295/android-webauthn-token) - A FIDO2 WebAuthn BLE Android phone token
+ - [soft-webauthn](https://github.com/bodik/soft-webauthn) - Python software webauthn token
 
 ## Hardware
  - `FIDO COMPLIANT` [Conor Patrick: U2F Zero](https://github.com/conorpp/u2f-zero) - U2F Zero is an open source U2F token for 2 factor authentication.


### PR DESCRIPTION
please consider software webauthn token based on yubico python-fido2 and usefull for continuous integration tests