### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@
  - [Radoslav Bodó: soft-webauthn](https://github.com/bodik/soft-webauthn) - Python software webauthn token
 
 ## Hardware
- - `FIDO COMPLIANT` [Conor Patrick: U2F Zero](https://github.com/conorpp/u2f-zero) - U2F Zero is an open source U2F token for 2 factor authentication.
- - `FIDO COMPLIANT` [SoloKeys](https://github.com/solokeys) - Solo is an open source FIDO2 security key, and you can get one at solokeys.com
- - [Trezor](https://github.com/trezor/trezor-core/tree/master/src/apps/webauthn) - Trezor is an open source hardware wallet with FIDO/U2F and FIDO2/WebAuthn functionality.
+- `FIDO CERTIFIED` [SoloKeys](https://github.com/solokeys) - Solo is an open source FIDO2 security key, and you can get one at solokeys.com
+- `FIDO COMPLIANT` [Conor Patrick: U2F Zero](https://github.com/conorpp/u2f-zero) - U2F Zero is an open source U2F token for 2 factor authentication.
+- [Trezor](https://github.com/trezor/trezor-core/tree/master/src/apps/webauthn) - Trezor is an open source hardware wallet with FIDO/U2F and FIDO2/WebAuthn functionality.
 
 # Resources
 ## Tutorials


### PR DESCRIPTION
Solo is a FIDO2 certified authenticator as of 1-Oct-2019.  See https://medium.com/solokeyssec/solokeys-achieves-fido2-certification-thanks-to-mozilla-4c9ea52c05dd.