### PR TITLE
Introduce a soft token section and add WearAuthn

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   - [Demos](#demos)
   - [Server Libs](#server-libs)
   - [Client Libs](#client-libs)
+  - [Soft tokens](#soft-tokens)
   - [Hardware](#hardware)
 
 - [Resources](#resources)
@@ -56,10 +57,13 @@
  - [Yubico: python-fido2](https://github.com/Yubico/python-fido2) - Client Lib to talk to a hardware authenticators over USB HID
  - [Yubico: libfido2](https://github.com/Yubico/libfido2) - C client library and command-line tools to communicate with a FIDO device over USB, and to verify attestation and assertion signatures.
  - [Lyo Kato: iOS Webauthn Kit](https://github.com/lyokato/WebAuthnKit) - This library provides you a way to handle W3C Web Authentication API (a.k.a. WebAuthN / FIDO 2.0) easily.
- - [Damian Czaja: android-webauthn-token](https://github.com/Trojan295/android-webauthn-token) - A FIDO2 WebAuthn BLE Android phone token
  - [Radoslav Bodó: soft-webauthn](https://github.com/bodik/soft-webauthn) - Python software webauthn token
  - [Yubico: Mobile iOS SDK (YubiKit)](https://github.com/Yubico/yubikit-ios) - YubiKit is an iOS library provided by Yubico to interact with YubiKeys on iOS devices. Works with other FIDO2 devices as well
-
+ 
+## Soft tokens
+ - [Damian Czaja: android-webauthn-token](https://github.com/Trojan295/android-webauthn-token) - A FIDO2 WebAuthn BLE Android phone token
+ - [Fabian Henneke: WearAuthn](https://github.com/FabianHenneke/WearAuthn) - FIDO2 Bluetooth HID/NFC soft token for Wear OS watches with support for resident keys
+ 
 ## Hardware
 - `FIDO CERTIFIED™` [SoloKeys](https://github.com/solokeys) - Solo is an open source FIDO2 security key, and you can get one at solokeys.com
 - `FIDO COMPLIANT` [Conor Patrick: U2F Zero](https://github.com/conorpp/u2f-zero) - U2F Zero is an open source U2F token for 2 factor authentication.


### PR DESCRIPTION
Introduces a section for soft tokens, which fit neither into the existing hardware nor the client lib section. Damian Czaja's android-webauthn-token is an example of such a soft token, this PR moves it into this new section.

It also adds WearAuthn to the list of soft tokens, which I developed to provide a full-fledged open-source implementation of the CTAP2 standard in a higher programming language (Kotlin/Java). It uses the watch's screen to show confirmation prompts and supports the on-device selection of resident credentials.