### PR TITLE
Add softauthn library

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
  - [Damian Czaja: android-webauthn-token](https://github.com/Trojan295/android-webauthn-token) - A FIDO2 WebAuthn BLE Android phone token
  - [Fabian Henneke: WearAuthn](https://github.com/FabianHenneke/WearAuthn) - FIDO2 Bluetooth HID/NFC soft token for Wear OS watches with support for resident keys
  - [Radoslav Bodó: soft-webauthn](https://github.com/bodik/soft-webauthn) - Python software webauthn token
+ - [adessoSE: softauthn](https://github.com/adessoSE/softauthn) - FIDO2 authenticator emulator/software token in Java
  - [Daniel Stiner: Rust U2F](https://github.com/danstiner/rust-u2f) - U2F security token emulator written in Rust
  - [Firstyear: webauthn-authenticator-rs](https://github.com/Firstyear/webauthn-rs) - Contains a software webauthn token with ephemeral attestation CA allowing richer testing of device policies
  


### PR DESCRIPTION
This PR adds the [softauthn](https://github.com/adessoSE/softauthn) library (maintained and developed by myself) to the list of software authenticators. The library is supposed to be the Java equivalent to the already listed `soft-webauthn` library for Python - it is an implementation of a WebAuthn authenticator and the WebAuthn API itself that can be used to test your Java backend.

One goal is to support most features (that make sense in a testing environment) in the WebAuthn spec. This is still being worked on, but the library can already be used for pretty thorough testing. It's especially well-suited to test backends that use the [java-webauthn-server](https://github.com/Yubico/java-webauthn-server) library because it uses the data models of this library.

Documentation in the readme can and will still be improved/more examples will be added, the javadocs are already pretty elaborate. All in all I'd say it's pretty straight-forward.

Future work will include support for more cryptographic algorithms, client extensions and testing different attestation formats.