### PR TITLE
Add RS-Key project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 - [WIOSense: rauth-android](https://github.com/WIOsense/rauth-android) - Android library for FIDO2 roaming authenticator.
 
 ## Software Authenticators
+- `FIDO CONFORMANT` [TheMaxMur: RS-Key](https://github.com/TheMaxMur/RS-Key) - FIDO2/WebAuthn and U2F security-key firmware for the RP2350, written in Rust with reproducible builds; also implements OpenPGP, PIV and OATH.
 - [Damian Czaja: android-webauthn-token](https://github.com/Trojan295/android-webauthn-token) - A FIDO2 WebAuthn BLE Android phone token.
 - [Fabian Henneke: WearAuthn](https://github.com/FabianHenneke/WearAuthn) - FIDO2 Bluetooth HID/NFC soft token for Wear OS watches with support for resident keys.
 - [Radoslav Bodó: soft-webauthn](https://github.com/bodik/soft-webauthn) - Python software webauthn token.


### PR DESCRIPTION
RS-Key is open-source (AGPL-3.0) FIDO2/WebAuthn + U2F security-key firmware for the RP2350, written in Rust — the same category as the existing pico-fido entry (open firmware that turns a Pi Pico 2 board into a USB authenticator). It additionally implements OpenPGP, PIV and OATH.